### PR TITLE
Make target options truly optional.

### DIFF
--- a/tasks/grunt-supervisor.js
+++ b/tasks/grunt-supervisor.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     var aOptions, oOptions;
     this.async();
     aOptions = [];
-    oOptions = this.data.options;
+    oOptions = this.data.options || {};
     if (grunt.util.kindOf(oOptions.watch) === "array") {
       aOptions.push("--watch", oOptions.watch.join(","));
     }


### PR DESCRIPTION
Documentation states that options can be omitted from the grunt task definition, but this will result in an error.  An empty object can be used in the task instead.

This commit allows the options to be ommitted entirely.
