### PR TITLE
add async as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ supervisor: {
       harmony: true
       noRestartOn: "exit",
       forceWatch: true,
-      quiet: true
+      quiet: true,
+      async: true
     }
   }
 }
@@ -120,6 +121,10 @@ This may be useful if you see a high cpu load on a windows machine.
 ##### quiet
 Type: `Boolean`  
 Suppress DEBUG messages
+
+##### async
+Type: `Boolean`  
+Keeps Grunt from exiting. Set to false if there is another task like "watch" folowing this one.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/tasks/grunt-supervisor.coffee
+++ b/tasks/grunt-supervisor.coffee
@@ -13,10 +13,10 @@ supervisor = require "supervisor"
 module.exports = ( grunt ) ->
 
     grunt.registerMultiTask "supervisor", "Runs a supervisor monitor of your node.js server.", ->
-        @async()
-
         aOptions = []
         oOptions = @data.options || {}
+
+        @async() unless oOptions.async == false
 
         aOptions.push "--watch", oOptions.watch.join "," if grunt.util.kindOf( oOptions.watch ) is "array"
         aOptions.push "--ignore", oOptions.ignore.join "," if grunt.util.kindOf( oOptions.ignore ) is "array"

--- a/tasks/grunt-supervisor.js
+++ b/tasks/grunt-supervisor.js
@@ -14,9 +14,11 @@ supervisor = require("supervisor");
 module.exports = function(grunt) {
   return grunt.registerMultiTask("supervisor", "Runs a supervisor monitor of your node.js server.", function() {
     var aOptions, oOptions;
-    this.async();
     aOptions = [];
     oOptions = this.data.options || {};
+    if (oOptions.async !== false) {
+      this.async();
+    }
     if (grunt.util.kindOf(oOptions.watch) === "array") {
       aOptions.push("--watch", oOptions.watch.join(","));
     }


### PR DESCRIPTION
Fixes the case when we have supervisor as the first of a series of tasks.
Eg:

```
grunt.registerTask('default', ['supervisor', 'watch']);
```
